### PR TITLE
Added support for building with vc17win64 (VS2022)

### DIFF
--- a/physx/buildtools/cmake_generate_projects.py
+++ b/physx/buildtools/cmake_generate_projects.py
@@ -127,10 +127,14 @@ class CMakePreset:
                     print('VS15CL:' + os.environ['VS150CLPATH'])
                     outString = outString + ' -DCUDA_HOST_COMPILER=' + \
                         os.environ['VS150CLPATH']
-                if self.compiler == 'vc16':
+                elif self.compiler == 'vc16':
                     print('VS16CL:' + os.environ['VS160CLPATH'])
                     outString = outString + ' -DCUDA_HOST_COMPILER=' + \
                         os.environ['VS160CLPATH']
+                elif self.compiler == 'vc17':
+                    print('VS17CL:' + os.environ['VS170CLPATH'])
+                    outString = outString + ' -DCUDA_HOST_COMPILER=' + \
+                        os.environ['VS170CLPATH']
 
         return outString
 
@@ -150,6 +154,8 @@ class CMakePreset:
             outString = outString + '-G \"Visual Studio 15 2017\"'
         elif self.compiler == 'vc16':
             outString = outString + '-G \"Visual Studio 16 2019\"'
+        elif self.compiler == 'vc17':
+            outString = outString + '-G \"Visual Studio 17 2022\"'
         elif self.compiler == 'xcode':
             outString = outString + '-G Xcode'
         elif self.targetPlatform == 'linux':

--- a/physx/buildtools/presets/public/vc17win64.xml
+++ b/physx/buildtools/presets/public/vc17win64.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<preset name="vc17win64" comment="VC17 Win64 PhysX general settings">
+  <platform targetPlatform="win64" compiler="vc17" />
+  <CMakeSwitches>
+    <cmakeSwitch name="PX_BUILDSNIPPETS" value="True" comment="Generate the snippets" />
+    <cmakeSwitch name="PX_BUILDPVDRUNTIME" value="True" comment="Generate the OmniPVD project" />
+    <cmakeSwitch name="PX_GENERATE_STATIC_LIBRARIES" value="False" comment="Generate static libraries" />
+    <cmakeSwitch name="NV_USE_STATIC_WINCRT" value="True" comment="Use the statically linked windows CRT" />
+    <cmakeSwitch name="NV_USE_DEBUG_WINCRT" value="True" comment="Use the debug version of the CRT" />
+    <cmakeSwitch name="PX_FLOAT_POINT_PRECISE_MATH" value="False" comment="Float point precise math" />
+  </CMakeSwitches>
+  <CMakeParams>
+    <cmakeParam name="CMAKE_INSTALL_PREFIX" value="install/vc17win64/PhysX" comment="Install path relative to PhysX SDK root" />
+  </CMakeParams>
+</preset>

--- a/physx/generate_projects.bat
+++ b/physx/generate_projects.bat
@@ -15,10 +15,14 @@ IF %1.==. GOTO ADDITIONAL_PARAMS_MISSING
 :: Run packman to ensure dependencies are present and run cmake generation script afterwards
 echo Running packman in preparation for cmake ...
 set str1=%1
+if "%str1%"=="vc17win64" (
+	set str1="vc16win64"
+)
+
 if not x%str1:.user=%==x%str1% (
   call "%~dp0buildtools\packman\packman.cmd" pull "%~dp0dependencies.xml" --platform %str1:.user=%
 ) else (
-  call "%~dp0buildtools\packman\packman.cmd" pull "%~dp0dependencies.xml" --platform %1
+  call "%~dp0buildtools\packman\packman.cmd" pull "%~dp0dependencies.xml" --platform %str1%
 )
 
 for /f "usebackq tokens=*" %%i in (`"%PM_vswhere_PATH%\VsWhere.exe  -version [15.0,16.0) -latest -property installationPath"`) do (
@@ -27,8 +31,13 @@ for /f "usebackq tokens=*" %%i in (`"%PM_vswhere_PATH%\VsWhere.exe  -version [15
 )
 
 for /f "usebackq tokens=*" %%i in (`"%PM_vswhere_PATH%\VsWhere.exe  -version [16.0,17.0) -latest -property installationPath"`) do (
-  set Install2019Dir=%%i
+	set Install2019Dir=%%i
 	set VS160PATH="%%i"
+)
+
+for /f "usebackq tokens=*" %%i in (`"%PM_vswhere_PATH%\VsWhere.exe  -version [17.0,18.0) -latest -property installationPath"`) do (
+	set Install2022Dir=%%i
+	set VS170PATH="%%i"
 )
 
 if exist "%Install2017Dir%\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt" (
@@ -50,6 +59,18 @@ if exist "%Install2019Dir%\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.t
 	if not %%x=="" (
 	  rem Example hardcodes x64 as the host and target architecture, but you could parse it from arguments
 	  set VS160CLPATH="%Install2019Dir%\VC\Tools\MSVC\%%x\bin\HostX64\x64\cl.exe"
+	)
+  )
+  popd
+)
+
+if exist "%Install2022Dir%\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt" (
+  pushd "%Install2022Dir%\VC\Auxiliary\Build\"
+  set /p Version=<Microsoft.VCToolsVersion.default.txt
+  for /f "delims=" %%x in (Microsoft.VCToolsVersion.default.txt) do (
+	if not %%x=="" (
+	  rem Example hardcodes x64 as the host and target architecture, but you could parse it from arguments
+	  set VS170CLPATH="%Install2022Dir%\VC\Tools\MSVC\%%x\bin\HostX64\x64\cl.exe"
 	)
   )
   popd


### PR DESCRIPTION
Adding support for building PhysX using the compiler from VS2022, but falling back to dependencies from Packman for VS2019 which works since 2022 is backwards compatible.