### PR TITLE
Support GCC 12 C++20 mode

### DIFF
--- a/physx/source/common/src/CmPreallocatingPool.h
+++ b/physx/source/common/src/CmPreallocatingPool.h
@@ -393,7 +393,7 @@ template<class T>
 class BufferedPreallocatingPool : public PreallocatingPool<T>
 {
 	PxArray<T*> mDeletedElems;
-	PX_NOCOPY(BufferedPreallocatingPool<T>)
+	PX_NOCOPY(BufferedPreallocatingPool)
 public:
 	BufferedPreallocatingPool(PxU32 maxElements, const char* typeName) : PreallocatingPool<T>(maxElements, typeName)
 	{

--- a/physx/source/physxmetadata/core/include/PvdMetaDataExtensions.h
+++ b/physx/source/physxmetadata/core/include/PvdMetaDataExtensions.h
@@ -299,7 +299,7 @@ template<typename TEnumType, typename TStorageType>
 struct IsFlagsType<PxFlags<TEnumType, TStorageType> > 
 {
 	const PxU32ToName* FlagData;
-	IsFlagsType<PxFlags<TEnumType, TStorageType> > () : FlagData( PxEnumTraits<TEnumType>().NameConversion ) {}
+	IsFlagsType() : FlagData( PxEnumTraits<TEnumType>().NameConversion ) {}
 };
 
 

--- a/physx/source/physxmetadata/core/include/PxMetaDataObjects.h
+++ b/physx/source/physxmetadata/core/include/PxMetaDataObjects.h
@@ -495,7 +495,7 @@ struct PxPropertyToValueStructMemberMap
 	template<> struct PxPropertyToValueStructMemberMap< PxPropertyInfoName::type##_##prop >												\
 	{																																	\
 		PxU32 Offset;																													\
-		PxPropertyToValueStructMemberMap< PxPropertyInfoName::type##_##prop >() : Offset( PX_OFFSET_OF_RT( valueStruct, prop ) ) {}		\
+		PxPropertyToValueStructMemberMap() : Offset( PX_OFFSET_OF_RT( valueStruct, prop ) ) {}											\
 		template<typename TOperator> void visitProp( TOperator inOperator, valueStruct& inStruct ) { inOperator( inStruct.prop );	}	\
 	};
 	

--- a/physx/source/physxmetadata/extensions/include/PxExtensionMetaDataObjects.h
+++ b/physx/source/physxmetadata/extensions/include/PxExtensionMetaDataObjects.h
@@ -56,7 +56,7 @@ struct PxExtensionsPropertyInfoName
 	template<> struct PxPropertyToValueStructMemberMap< PxExtensionsPropertyInfoName::type##_##prop >											\
 	{																																			\
 		PxU32 Offset;																															\
-		PxPropertyToValueStructMemberMap< PxExtensionsPropertyInfoName::type##_##prop >() : Offset( PX_OFFSET_OF_RT( valueStruct, prop ) ) {}	\
+		PxPropertyToValueStructMemberMap() : Offset( PX_OFFSET_OF_RT( valueStruct, prop ) ) {}													\
 		template<typename TOperator> void visitProp( TOperator inOperator, valueStruct& inStruct ) { inOperator( inStruct.prop );	}			\
 	};
 

--- a/physx/source/physxvehicle/src/physxmetadata/include/PxVehicleMetaDataObjects.h
+++ b/physx/source/physxvehicle/src/physxmetadata/include/PxVehicleMetaDataObjects.h
@@ -55,7 +55,7 @@ struct PxVehiclePropertyInfoName
 	template<> struct PxPropertyToValueStructMemberMap< PxVehiclePropertyInfoName::type##_##prop >									\
 	{																																	\
 		PxU32 Offset;																													\
-		PxPropertyToValueStructMemberMap< PxVehiclePropertyInfoName::type##_##prop >() : Offset( PX_OFFSET_OF_RT( valueStruct, prop ) ) {}	\
+		PxPropertyToValueStructMemberMap() : Offset( PX_OFFSET_OF_RT( valueStruct, prop ) ) {}											\
 		template<typename TOperator> void visitProp( TOperator inOperator, valueStruct& inStruct ) { inOperator( inStruct.prop );	}	\
 	};
 

--- a/physx/source/pvd/include/PxPvdObjectModelBaseTypes.h
+++ b/physx/source/pvd/include/PxPvdObjectModelBaseTypes.h
@@ -254,7 +254,7 @@ struct PvdDataTypeToNamespacedNameMap
 	struct PvdDataTypeToNamespacedNameMap<type>                                                                        \
 	{                                                                                                                  \
 		NamespacedName Name;                                                                                           \
-		PvdDataTypeToNamespacedNameMap<type>() : Name("physx3", #type)                                                 \
+		PvdDataTypeToNamespacedNameMap() : Name("physx3", #type)                                                       \
 		{                                                                                                              \
 		}                                                                                                              \
 	};                                                                                                                 \
@@ -262,7 +262,7 @@ struct PvdDataTypeToNamespacedNameMap
 	struct PvdDataTypeToNamespacedNameMap<const type&>                                                                 \
 	{                                                                                                                  \
 		NamespacedName Name;                                                                                           \
-		PvdDataTypeToNamespacedNameMap<const type&>() : Name("physx3", #type)                                          \
+		PvdDataTypeToNamespacedNameMap() : Name("physx3", #type)                                                       \
 		{                                                                                                              \
 		}                                                                                                              \
 	};
@@ -286,7 +286,7 @@ inline NamespacedName getPvdNamespacedNameForType()
 	struct PvdDataTypeToNamespacedNameMap<type>                                                                        \
 	{                                                                                                                  \
 		NamespacedName Name;                                                                                           \
-		PvdDataTypeToNamespacedNameMap<type>() : Name(ns, name)                                                        \
+		PvdDataTypeToNamespacedNameMap() : Name(ns, name)                                                              \
 		{                                                                                                              \
 		}                                                                                                              \
 	};
@@ -296,7 +296,7 @@ inline NamespacedName getPvdNamespacedNameForType()
 	struct PvdDataTypeToNamespacedNameMap<newType>                                                                     \
 	{                                                                                                                  \
 		NamespacedName Name;                                                                                           \
-		PvdDataTypeToNamespacedNameMap<newType>() : Name(PvdDataTypeToNamespacedNameMap<oldType>().Name)               \
+		PvdDataTypeToNamespacedNameMap() : Name(PvdDataTypeToNamespacedNameMap<oldType>().Name)                        \
 		{                                                                                                              \
 		}                                                                                                              \
 	};

--- a/physx/source/pvd/src/PxProfileZoneImpl.h
+++ b/physx/source/pvd/src/PxProfileZoneImpl.h
@@ -78,7 +78,7 @@ namespace physx { namespace profile {
 		PxProfileArray<PxProfileZoneClient*>			mZoneClients;
 		volatile bool									mEventsActive;
 
-		PX_NOCOPY(ZoneImpl<TNameProvider>)
+		PX_NOCOPY(ZoneImpl)
 	public:
 		ZoneImpl( PxAllocatorCallback* inAllocator, const char* inName, uint32_t bufferSize = 0x10000 /*64k*/, const TNameProvider& inProvider = TNameProvider() )
 			: TZoneEventBufferType( inAllocator, bufferSize, PxDefaultContextProvider(), NULL, PxProfileNullEventFilter() )

--- a/physx/source/pvd/src/PxPvdObjectModelInternalTypes.h
+++ b/physx/source/pvd/src/PxPvdObjectModelInternalTypes.h
@@ -80,7 +80,7 @@ struct PvdTypeToDataTypeMap
 	struct PvdDataTypeToNamespacedNameMap<type>                                                                        \
 	{                                                                                                                  \
 		NamespacedName Name;                                                                                           \
-		PvdDataTypeToNamespacedNameMap<type>() : Name("physx3_debugger_internal", #type)                               \
+		PvdDataTypeToNamespacedNameMap() : Name("physx3_debugger_internal", #type)                                     \
 		{                                                                                                              \
 		}                                                                                                              \
 	};


### PR DESCRIPTION
This fix just removes a few templates which is needed since C++20 breaks previously valid code. See
https://timsong-cpp.github.io/cppwp/n4861/diff.cpp17.class

This is basically what is allowed and not in c++20:

template<class T>
struct A {
  A<T>();  // error: simple-template-id not allowed for constructor
  A(int);  // OK, injected-class-name used
  ~A<T>(); // error: simple-template-id not allowed for destructor
};
