### PR TITLE
Fix contact generation with a (absolute) separation value higher than…

### DIFF
--- a/physx/source/geomutils/src/contact/GuContactCapsuleMesh.cpp
+++ b/physx/source/geomutils/src/contact/GuContactCapsuleMesh.cpp
@@ -195,7 +195,7 @@ static void PxcGenerateVFContacts(	const PxMat34& meshAbsPose, PxContactBuffer& 
 	{
 		const PxVec3& Pos = Ptr[i];
 		PxReal t,u,v;
-		if(intersectRayTriangleCulling(Pos, -normal, triVerts[0], triVerts[1], triVerts[2], t, u, v, 1e-3f) && t < radius + contactDistance)
+		if(intersectRayTriangleCulling(Pos, -normal, triVerts[0], triVerts[1], triVerts[2], t, u, v, 1e-3f) && physx::intrinsics::abs(t) < radius + contactDistance)
 		{
 			const PxVec3 Hit = meshAbsPose.transform(Pos - t * normal);
 			const PxVec3 wn = meshAbsPose.rotate(normal);


### PR DESCRIPTION
See issue #156 

### Description
For Capsule-Mesh contact generation, contacts can be generated whose seperation value is higher than the contact offset.
In some scenarios (image below) with relatively thin objects this can lead to contacts being generated on the opposite side of the colliding objects.
