### PR TITLE
Calculation error in ConvexMeshSupport::supportLocal

### DIFF
--- a/physx/source/physxextensions/src/ExtGjkQueryExt.cpp
+++ b/physx/source/physxextensions/src/ExtGjkQueryExt.cpp
@@ -146,7 +146,7 @@ PxVec3 PxGjkQueryExt::ConvexMeshSupport::supportLocal(const PxVec3& dir) const
 	if (convexMesh == NULL)
 		return PxVec3(0.0f);
 
-	PxVec3 d = scaleRotation.rotateInv(scaleRotation.rotate(dir).multiply(PxVec3(scale.x, scale.y, scale.z)));
+	PxVec3 d = scaleRotation.rotateInv(scaleRotation.rotate(dir).multiply(scale));
 	const PxVec3* verts = convexMesh->getVertices();
 	int count = int(convexMesh->getNbVertices());
 	float maxDot = -FLT_MAX;

--- a/physx/source/physxextensions/src/ExtGjkQueryExt.cpp
+++ b/physx/source/physxextensions/src/ExtGjkQueryExt.cpp
@@ -146,7 +146,7 @@ PxVec3 PxGjkQueryExt::ConvexMeshSupport::supportLocal(const PxVec3& dir) const
 	if (convexMesh == NULL)
 		return PxVec3(0.0f);
 
-	PxVec3 d = scaleRotation.rotateInv(scaleRotation.rotate(dir).multiply(PxVec3(1.0f / scale.x, 1.0f / scale.y, 1.0f / scale.z)));
+	PxVec3 d = scaleRotation.rotateInv(scaleRotation.rotate(dir).multiply(PxVec3(1.0f, 1.0f, 1.0f)));
 	const PxVec3* verts = convexMesh->getVertices();
 	int count = int(convexMesh->getNbVertices());
 	float maxDot = -FLT_MAX;

--- a/physx/source/physxextensions/src/ExtGjkQueryExt.cpp
+++ b/physx/source/physxextensions/src/ExtGjkQueryExt.cpp
@@ -146,7 +146,7 @@ PxVec3 PxGjkQueryExt::ConvexMeshSupport::supportLocal(const PxVec3& dir) const
 	if (convexMesh == NULL)
 		return PxVec3(0.0f);
 
-	PxVec3 d = scaleRotation.rotateInv(scaleRotation.rotate(dir).multiply(PxVec3(1.0f, 1.0f, 1.0f)));
+	PxVec3 d = scaleRotation.rotateInv(scaleRotation.rotate(dir).multiply(PxVec3(scale.x, scale.y, scale.z)));
 	const PxVec3* verts = convexMesh->getVertices();
 	int count = int(convexMesh->getNbVertices());
 	float maxDot = -FLT_MAX;


### PR DESCRIPTION
By PxMeshScale::toMat33, we have
`f(v) = T * v`,
where `T = tr(R) * S * R` and
- tr(R): transpose of R,
- S:      diagonal matrix containing the scaling factors,
- R:      rotation matrix from local mesh space to scaling space,
- v:      any point of the unscaled mesh,
- f(v):   scaled point.

The support function is the supremum of the dot products
`dot(dir, T * v) = tr(dir) * (T * v) = dot(tr(tr(dir) * T), v) = dot(tr(T) * dir, v)`,
where dir is a vector (PxVec3) and
`tr(T) = tr(R) * tr(S) * R = T`,
since S is a diagonal matrix. Thus, S is not supposed to be inverted in the expression of tr(T).

Finally, let us look at a simple example that demonstrates that the current implementation might be wrong:
```
// Excerpt of ConvexMeshSupport::supportLocal
PxVec3 v(1.f, 0.f, 0.f);
PxVec3 dir(1.f, 0.f, 0.f);
PxQuat scaleRotation(PxIdentity);
PxVec3 scale(2.f, 2.f, 2.f);

// Note that d = tr(T) = T
PxVec3 d= scaleRotation.rotateInv(scaleRotation.rotate(dir).multiply(PxVec3(1.0f / scale.x, 1.0f / scale.y, 1.0f / scale.z)));
// In this example, we actually have d = dir.multiply(PxVec3(1.0f / scale.x, 1.0f / scale.y, 1.0f / scale.z));
float dot = v.dot(d);
```
We get dot  = 0.5, while the correct solution is dot  = 2.
