### PR TITLE
Fix crash / invalid read inside  Sc::Scene::beforeSolver

### DIFF
--- a/physx/source/simulationcontroller/src/ScArticulationSim.cpp
+++ b/physx/source/simulationcontroller/src/ScArticulationSim.cpp
@@ -94,6 +94,8 @@ Sc::ArticulationSim::~ArticulationSim()
 
 	mScene.getSimpleIslandManager()->removeNode(mIslandNodeIndex);
 
+	mScene.getVelocityModifyMap().boundedReset( mIslandNodeIndex.index() );
+
 	mCore.setSim(NULL);
 }
 

--- a/physx/source/simulationcontroller/src/ScBodySim.cpp
+++ b/physx/source/simulationcontroller/src/ScBodySim.cpp
@@ -147,6 +147,8 @@ BodySim::~BodySim()
 	if(mArticulation == NULL && mNodeIndex.articulationLinkId() == 0) //If it wasn't an articulation link, then we can remove it
 		scene.getSimpleIslandManager()->removeNode(mNodeIndex);
 
+	mScene.getVelocityModifyMap().boundedReset( mNodeIndex.index() );
+
 	PX_ASSERT(mActiveListIndex != SC_NOT_IN_SCENE_INDEX);
 
 	if (active)
@@ -242,6 +244,12 @@ void BodySim::switchToKinematic()
 		//   triggers onDeactivate() on the constraint pairs that are active. If such pairs get deactivated, they will get removed from the list of active breakable
 		//   constraints automatically.
 		setActorsInteractionsDirty(InteractionDirtyFlag::eBODY_KINEMATIC, NULL, InteractionFlag::eFILTERABLE);
+
+		if( isKinematic() == false )
+		{
+			// Reset the index inside the velocity map (bounded because there is no evidence that it is present) because set to kinemetic will call removeNodeFromIsland
+			getScene().getVelocityModifyMap().boundedReset( mNodeIndex.index() );
+		}
 
 		mScene.getSimpleIslandManager()->setKinematic(mNodeIndex);
 

--- a/physx/source/simulationcontroller/src/ScFEMClothSim.cpp
+++ b/physx/source/simulationcontroller/src/ScFEMClothSim.cpp
@@ -61,6 +61,8 @@ Sc::FEMClothSim::~FEMClothSim()
 
 	mScene.getSimpleIslandManager()->removeNode(mNodeIndex);
 
+	mScene.getVelocityModifyMap().boundedReset(mNodeIndex.index());
+
 	mCore.setSim(NULL);
 }
 

--- a/physx/source/simulationcontroller/src/ScHairSystemSim.cpp
+++ b/physx/source/simulationcontroller/src/ScHairSystemSim.cpp
@@ -63,6 +63,8 @@ Sc::HairSystemSim::~HairSystemSim()
 
 	mScene.destroyLLHairSystem(*mLLHairSystem);
 	mScene.getSimpleIslandManager()->removeNode(mNodeIndex);
+	mScene.getVelocityModifyMap().boundedReset(mNodeIndex.index());
+
 	mCore.setSim(NULL);
 }
 

--- a/physx/source/simulationcontroller/src/ScParticleSystemSim.cpp
+++ b/physx/source/simulationcontroller/src/ScParticleSystemSim.cpp
@@ -69,6 +69,7 @@ Sc::ParticleSystemSim::~ParticleSystemSim()
 	mScene.destroyLLParticleSystem(*mLLParticleSystem);
 
 	mScene.getSimpleIslandManager()->removeNode(mNodeIndex);
+	mScene.getVelocityModifyMap().boundedReset(mNodeIndex.index());
 
 	mCore.setSim(NULL);
 }

--- a/physx/source/simulationcontroller/src/ScScene.cpp
+++ b/physx/source/simulationcontroller/src/ScScene.cpp
@@ -1685,6 +1685,9 @@ void Sc::Scene::removeBody(BodySim& body)	//this also notifies any connected joi
 	else
 		PX_ASSERT(!isInPosePreviewList(body));
 
+	// Using bounded because on the other side we are using grow&set that can grow the map, so there is no evidence that the index is valid to reset if it was never inserted
+	mVelocityModifyMap.boundedReset(body.getNodeIndex().index());
+
 	markReleasedBodyIDForLostTouch(body.getActorID());
 }
 

--- a/physx/source/simulationcontroller/src/ScSoftBodySim.cpp
+++ b/physx/source/simulationcontroller/src/ScSoftBodySim.cpp
@@ -58,6 +58,8 @@ Sc::SoftBodySim::~SoftBodySim()
 
 	mScene.getSimpleIslandManager()->removeNode(mNodeIndex);
 
+	mScene.getVelocityModifyMap().boundedReset(mNodeIndex.index());
+
 	mCore.setSim(NULL);
 }
 


### PR DESCRIPTION

This commit fix the crash / invalid read described inside issue #211 .

I simply reset the ``sc::Scene::mVelocityModifyMap`` map for the given node index

I prefered to be ultra safe with this commit and use the method ``PxBitMap::boundedReset`` every time a call to ``Sc::Scene::removeNode`` is done. 

Maybe the only necessary call is inside ``Sc::Scene::removeBody``.