### PR TITLE
added leapfrog integration

### DIFF
--- a/physx/source/lowlevel/software/include/PxsRigidBody.h
+++ b/physx/source/lowlevel/software/include/PxsRigidBody.h
@@ -123,6 +123,8 @@ class PxsRigidBody
 	PX_FORCE_INLINE	void				clearFreezeFlag()							{ mInternalFlags &= ~eFREEZE_THIS_FRAME;					}
 	PX_FORCE_INLINE	void				clearUnfreezeFlag()							{ mInternalFlags &= ~eUNFREEZE_THIS_FRAME;					}
 	PX_FORCE_INLINE	void				clearAllFrameFlags()						{ mInternalFlags &= ~(eFREEZE_THIS_FRAME | eUNFREEZE_THIS_FRAME | eACTIVATE_THIS_FRAME | eDEACTIVATE_THIS_FRAME);	}
+	PX_FORCE_INLINE void				setLeapfrogAccelerationScale()				{ mAccelScale = 0.5f;										}
+	PX_FORCE_INLINE void				resetLeapfrogAccelerationScale()			{ mAccelScale = 1.0f;										}
 
 	PX_FORCE_INLINE	void				resetSleepFilter()							{ mSleepAngVelAcc = mSleepLinVelAcc = PxVec3(0.0f);			}
 

--- a/physx/source/simulationcontroller/src/ScBodySim.cpp
+++ b/physx/source/simulationcontroller/src/ScBodySim.cpp
@@ -670,11 +670,14 @@ bool BodySim::updateForces(PxReal dt, PxsRigidBody** updatedBodySims, PxU32* upd
 	if( (accDirty || velDirty) && ((simStateData = getSimStateData(false)) != NULL) )
 	{
 		VelocityMod* velmod = simStateData->getVelocityModData();
+		PxReal accelScale = 1.f;
 
 		//we don't have support for articulation yet
 		if (updatedBodySims)
 		{
-			updatedBodySims[index] = &getLowLevelBody();
+			PxsRigidBody& body = getLowLevelBody();
+			accelScale = body.mAccelScale;
+			updatedBodySims[index] = &body;
 			updatedBodyNodeIndices[index++] = getNodeIndex().index();
 		}
 
@@ -686,7 +689,7 @@ bool BodySim::updateForces(PxReal dt, PxsRigidBody** updatedBodySims, PxU32* upd
 		
 		if (accDirty)
 		{
-			linVelDt += velmod->getLinearVelModPerSec()*dt;
+			linVelDt += velmod->getLinearVelModPerSec()*dt*accelScale;
 			angVelDt += velmod->getAngularVelModPerSec()*dt;
 		}
 

--- a/physx/source/simulationcontroller/src/ScPipeline.cpp
+++ b/physx/source/simulationcontroller/src/ScPipeline.cpp
@@ -2277,6 +2277,17 @@ void Sc::Scene::afterIntegration(PxBaseTask* continuation)
 
 		const IG::IslandSim& islandSim = mSimpleIslandManager->getAccurateIslandSim();
 
+		{
+			// clear leapfrog acceleration scale for all active bodies
+			const PxU32 nbActiveBodies = islandSim.getNbActiveNodes(IG::Node::eRIGID_BODY_TYPE);
+			const PxNodeIndex*const activeBodies = islandSim.getActiveNodes(IG::Node::eRIGID_BODY_TYPE);
+			for (PxU32 i = 0; i < nbActiveBodies; ++i)
+			{
+				PxsRigidBody* body = islandSim.getRigidBody(activeBodies[i]);
+				body->resetLeapfrogAccelerationScale();
+			}
+		}
+
 		const PxU32 rigidBodyOffset = BodySim::getRigidBodyOffset();
 
 		const PxU32 numBodiesToDeactivate = islandSim.getNbNodesToDeactivate(IG::Node::eRIGID_BODY_TYPE);

--- a/physx/source/simulationcontroller/src/ScScene.cpp
+++ b/physx/source/simulationcontroller/src/ScScene.cpp
@@ -2765,6 +2765,8 @@ void Sc::Scene::onBodySleep(BodySim* body)
 
 void Sc::Scene::onBodyWakeUp(BodySim* body)
 {
+	body->getLowLevelBody().setLeapfrogAccelerationScale();
+
 	if(!mSimulationEventCallback && !mOnSleepingStateChanged)
 		return;
 


### PR DESCRIPTION
Leapfrog integration applies half of the first acceleration update to velocity on the first frame after waking. After that, the updates proceed as usual with the full acceleration applied each frame. This corrects for impulses which otherwise have too much of the first frame's acceleration applied to them and lose mechincal energy as a result.

This fixes issue #308 

I have also included some tests here: 
https://github.com/LSBUGPG/PhysXJump/tree/test-without-leapfrog-integration
https://github.com/LSBUGPG/PhysXJump/tree/test-leapfrog-integration

Leapfrog integration is implemented by setting `PxsRigidBody::mAccelScale` to 0.5 when a body is first woken up (or added to a scene with an initial velocity) in `Sc::Scene::onBodyWakeUp`. It then resets this scale back to 1.0 after integration for all active bodies in `Sc::Scene::afterIntegration`. `PxsRigidBody::mAccelScale` is already used when applying the acceleration from the built in gravity. I've also modified `BodySim::updateForces` to use this value when manually applying gravity (or any other acceleration.)