### PR TITLE
Update README_LINUX.md

### DIFF
--- a/physx/documentation/platformreadme/linux/README_LINUX.md
+++ b/physx/documentation/platformreadme/linux/README_LINUX.md
@@ -9,17 +9,17 @@
 * CMake, minimum version 3.14
 * Python, minimum version 3.5
 * curl
+* Clang for linux x86-64
 * glibc, version 2.31 or higher (Note: GLIBC versions are typically not backwards compatible)
 
 ### Compilers and C++ Standard:
-  * We support only Ubuntu LTS releases for both x86-64 and aarch64 builds:
-    * For linux x86-64 builds:
-      * clang:
-        * Ubuntu 20.04 LTS with clang 10
-        * Ubuntu 22.04 LTS with clang 14 
+  * We support the following Ubuntu LTS releases:
+    * For linux x86-64 (clang only):
+      * Ubuntu 20.04 LTS with clang 10
+      * Ubuntu 22.04 LTS with clang 14 
       * Note: PhysX may fail to compile with clang versions higher than 14 as they have not been tested.
-    * For linux aarch64 builds:
-      * gcc, version 9
+    * For linux aarch64 (gcc only):
+      * Ubuntu 20.04 LTS with gcc 9
   * Tested with C++11 standard
 
 ## Generating Makefiles:

--- a/physx/documentation/platformreadme/linux/README_LINUX.md
+++ b/physx/documentation/platformreadme/linux/README_LINUX.md
@@ -1,25 +1,27 @@
+
 # NVIDIA PhysX SDK for Linux
 
 ## Location of Binaries:
 
 * SDK libraries: bin/linux.clang
 
-
 ## Required packages to generate projects:
 
 * CMake, minimum version 3.14
 * Python, minimum version 3.5
 * curl
-* For linux x86-64: glibc, version 2.31 or higher (Note: GLIBC versions are typically not backwards compatible)
+* glibc, version 2.31 or higher (Note: GLIBC versions are typically not backwards compatible)
 
-Compilers and C++ Standard:
-  * For linux x86-64 builds we support Ubuntu LTS releases with their respective default compiler versions:
-    * Ubuntu 20.04 LTS with gcc 9 or clang 10
-    * Ubuntu 22.04 LTS with gcc 11 or clang 14 
-    * Note: PhysX may fail to compile with clang versions higher than 14 as they have not been tested
-  * For linux aarch64 builds we support gcc version 9
+### Compilers and C++ Standard:
+  * We support only Ubuntu LTS releases for both x86-64 and aarch64 builds:
+    * For linux x86-64 builds:
+      * clang:
+        * Ubuntu 20.04 LTS with clang 10
+        * Ubuntu 22.04 LTS with clang 14 
+      * Note: PhysX may fail to compile with clang versions higher than 14 as they have not been tested.
+    * For linux aarch64 builds:
+      * gcc, version 9
   * Tested with C++11 standard
-
 
 ## Generating Makefiles:
 
@@ -27,17 +29,15 @@ Compilers and C++ Standard:
 * The script generate_projects.sh expects a preset name as a parameter, if a parameter is not provided it does list the available presets and you can select one.
 * Generated solutions are placed in the folders compiler/linux-debug, compiler/linux-checked, compiler/linux-profile, compiler/linux-release.
 
-
 ## Building SDK:
 
-* Makefiles are in compiler/linux-debug etc
-* Clean solution: make clean
-* Build solution: make
-* Install solution: make install
+* Makefiles are located in compiler/linux-debug, etc.
+* Clean solution: `make clean`
+* Build solution: `make`
+* Install solution: `make install`
 
 Note:
-Compile errors on unsupported compilers or platforms are frequently caused by additional warnings that are treated as errors by default.
-While we cannot offer support in this case we recommend removing all occurences of the `-Werror` flag in the file `physx/source/compiler/cmake/linux/CMakeLists.txt`.
+Compile errors on unsupported compilers or platforms are frequently caused by additional warnings that are treated as errors by default. While we cannot offer support in this case, we recommend removing all occurrences of the `-Werror` flag in the file `physx/source/compiler/cmake/linux/CMakeLists.txt`.
 
 ## PhysX GPU Acceleration:
 
@@ -55,5 +55,4 @@ While we cannot offer support in this case we recommend removing all occurences 
 ## How to select the PhysX GPU Device:
 
 * Set the environment variable PHYSX_GPU_DEVICE to the device ordinal on which GPU PhysX should run. Default is 0.
-* Example: export PHYSX_GPU_DEVICE="1"
-
+* Example: `export PHYSX_GPU_DEVICE="1"`

--- a/physx/documentation/platformreadme/linux/README_LINUX.md
+++ b/physx/documentation/platformreadme/linux/README_LINUX.md
@@ -1,4 +1,3 @@
-
 # NVIDIA PhysX SDK for Linux
 
 ## Location of Binaries:


### PR DESCRIPTION
Updated README to reflect build requirements for Linux:
- Removed GCC support for x86-64 builds, now only supporting Clang.
- Clarified that both x86-64 and aarch64 builds are supported only on Ubuntu LTS releases.
- Updated compiler version requirements for Clang (10 for Ubuntu 20.04, 14 for Ubuntu 22.04).
- Retained GCC support for aarch64 builds with version 9.
