### PR TITLE
[BR] Fix integer overflow in physx::writeCompressedContact causing sim corruption

### DIFF
--- a/physx/include/PxContact.h
+++ b/physx/include/PxContact.h
@@ -106,7 +106,7 @@ struct PxContactPatch
 	/**
 	\brief The number of contacts in this patch
 	*/
-	PxU8	nbContacts;
+	PxU16	nbContacts;
 
 	/**
 	\brief The combined material flag of two actors that come in contact
@@ -129,7 +129,7 @@ struct PxContactPatch
 	*/
 	PxU16	materialIndex1;
 
-	PxU16	pad[5];
+	PxU16	pad[4];
 }
 PX_ALIGN_SUFFIX(16);
 

--- a/physx/source/lowlevel/common/src/pipeline/PxcNpContactPrepShared.cpp
+++ b/physx/source/lowlevel/common/src/pipeline/PxcNpContactPrepShared.cpp
@@ -64,10 +64,10 @@ void combineMaterials(const PxsMaterialManager* materialManager, PxU16 origMatIn
 
 struct StridePatch
 {
-	PxU8 startIndex;
-	PxU8 endIndex;
+	PxU16 startIndex;
+	PxU16 endIndex;
+	PxU16 totalCount;
 	PxU8 nextIndex;
-	PxU8 totalCount;
 	bool isRoot;
 };
 
@@ -116,13 +116,13 @@ PxU32 physx::writeCompressedContact(const PxContactPoint* const PX_RESTRICT cont
 			{
 				StridePatch& patch = stridePatches[numStrideHeaders-1];
 
-				patch.startIndex = PxU8(strideStart);
-				patch.endIndex = PxU8(a);
+				patch.startIndex = PxU16(strideStart);
+				patch.endIndex = PxU16(a);
 				patch.nextIndex = 0xFF;
-				patch.totalCount = PxU8(a - strideStart);
+				patch.totalCount = PxU16(a - strideStart);
 				patch.isRoot = root;
 				if(parentRootPatch)
-					parentRootPatch->totalCount += PxU8(a - strideStart);
+					parentRootPatch->totalCount += PxU16(a - strideStart);
 
 				root = true;
 				parentRootPatch = NULL;
@@ -163,15 +163,16 @@ PxU32 physx::writeCompressedContact(const PxContactPoint* const PX_RESTRICT cont
 	}
 	{
 		StridePatch& patch = stridePatches[numStrideHeaders-1];
-		patch.startIndex = PxU8(strideStart);
-		patch.endIndex = PxU8(numContactPoints);
+		patch.startIndex = PxU16(strideStart);
+		patch.endIndex = PxU16(numContactPoints);
 		patch.nextIndex = 0xFF;
-		patch.totalCount = PxU8(numContactPoints - strideStart);
+		patch.totalCount = PxU16(numContactPoints - strideStart);
 		patch.isRoot = root;
 		if(parentRootPatch)
-			parentRootPatch->totalCount += PxU8(numContactPoints - strideStart);
+			parentRootPatch->totalCount += PxU16(numContactPoints - strideStart);
 	}
 
+	PX_ASSERT(totalUniquePatches <= PX_MAX_U8);
 	numPatches = PxU8(totalUniquePatches);
 
 	//Calculate the number of patches/points required

--- a/physx/source/lowlevel/software/src/PxsNphaseImplementationContext.cpp
+++ b/physx/source/lowlevel/software/src/PxsNphaseImplementationContext.cpp
@@ -242,9 +242,9 @@ public:
 								patches[k + 1].materialFlags = patches[k].materialFlags;
 								patches[k + 1].internalFlags = patches[k].internalFlags;
 								patches[k + 1].startContactIndex = PxTo8(j + startIndex);
-								patches[k + 1].nbContacts = PxTo8(patches[k].nbContacts - j);
+								patches[k + 1].nbContacts = PxTo16(patches[k].nbContacts - j);
 								//Fill in patch information now that final patches are available
-								patches[k].nbContacts = PxU8(j);
+								patches[k].nbContacts = PxU16(j);
 								break; // we're done with all contacts in patch k because the remaining were just transferrred to patch k+1
 							}
 						}


### PR DESCRIPTION
If a contact buffer has exactly 256 contacts in it, the endIndex on its last StrideBatch will overflow from 256 to 0, causing it to fail to copy the last batch of contacts but still setting the output count to include it, sending uninitialized garbage data into the solver, which kills the simulation very quickly.

Example of 256 input contacts to the function
![image](https://github.com/user-attachments/assets/cb2e6a94-5fd1-4ce1-aae2-c4b39c7c5420)

Corresponding grouped output contacts, note the last group is garbage
![image](https://github.com/user-attachments/assets/cbac6fc4-c18d-48de-ac50-ad30faf509a7)

The root cause is this u8 overflowing back to 0
![image](https://github.com/user-attachments/assets/827ad269-c2b0-4291-9c95-ea7ac6d0f43e)

We can fix it easily by using PxU16 instead so it can hold the proper count

cc @PierreTerdiman