### PR TITLE
Fix scalars implementation of vectorised min/max and checked assert

### DIFF
--- a/physx/include/foundation/PxVecMathAoSScalarInline.h
+++ b/physx/include/foundation/PxVecMathAoSScalarInline.h
@@ -1276,14 +1276,14 @@ PX_FORCE_INLINE Vec4V V4Min(const Vec4V a, const Vec4V b)
 PX_FORCE_INLINE FloatV V4ExtractMax(const Vec4V a)
 {
 	const PxF32 t0 = (a.x >= a.y) ? a.x : a.y;
-	const PxF32 t1 = (a.z >= a.w) ? a.x : a.w;
+	const PxF32 t1 = (a.z >= a.w) ? a.z : a.w;
 	return t0 >= t1 ? t0 : t1;
 }
 
 PX_FORCE_INLINE FloatV V4ExtractMin(const Vec4V a)
 {
 	const PxF32 t0 = (a.x <= a.y) ? a.x : a.y;
-	const PxF32 t1 = (a.z <= a.w) ? a.x : a.w;
+	const PxF32 t1 = (a.z <= a.w) ? a.z : a.w;
 	return t0 <= t1 ? t0 : t1;
 }
 

--- a/physx/source/physx/src/NpFactory.cpp
+++ b/physx/source/physx/src/NpFactory.cpp
@@ -24,7 +24,7 @@
 //
 // Copyright (c) 2008-2025 NVIDIA Corporation. All rights reserved.
 // Copyright (c) 2004-2008 AGEIA Technologies, Inc. All rights reserved.
-// Copyright (c) 2001-2004 NovodeX AG. All rights reserved.  
+// Copyright (c) 2001-2004 NovodeX AG. All rights reserved.
 
 #include "geometry/PxGeometryQuery.h"
 #include "NpFactory.h"
@@ -72,7 +72,7 @@ NpFactory::NpFactory() :
 	, mMaterialPool("MaterialPool")
 #if PX_SUPPORT_PVD
 	, mNpFactoryListener(NULL)
-#endif	
+#endif
 {
 }
 
@@ -199,7 +199,7 @@ void NpFactory::addArticulation(PxArticulationReducedCoordinate* npArticulation,
 void NpFactory::releaseArticulationToPool(PxArticulationReducedCoordinate& articulation)
 {
 	PX_ASSERT(articulation.getBaseFlags() & PxBaseFlag::eOWNS_MEMORY);
-	
+
 	PX_ASSERT(articulation.getConcreteType() == PxConcreteType::eARTICULATION_REDUCED_COORDINATE);
 	PxMutex::ScopedLock lock(mArticulationRCPoolLock);
 	mArticulationRCPool.destroy(static_cast<NpArticulationReducedCoordinate*>(&articulation));
@@ -233,7 +233,7 @@ NpArticulationLink* NpFactory::createNpArticulationLink(NpArticulationReducedCoo
 {
 	NpArticulationLink* npArticulationLink;
 	{
-		PxMutex::ScopedLock lock(mArticulationLinkPoolLock);		
+		PxMutex::ScopedLock lock(mArticulationLinkPoolLock);
 		npArticulationLink = mArticulationLinkPool.construct(pose, root, parent);
 	}
 	return npArticulationLink;
@@ -251,7 +251,7 @@ PxArticulationLink* NpFactory::createArticulationLink(NpArticulationReducedCoord
 {
 	PX_CHECK_AND_RETURN_NULL(pose.isValid(),"Supplied articulation link pose is not valid. Articulation link creation method returns NULL.");
 	PX_CHECK_AND_RETURN_NULL((!parent || (&parent->getRoot() == &root)), "specified parent link is not part of the destination articulation. Articulation link creation method returns NULL.");
-	
+
 	NpArticulationLink* npArticulationLink = NpFactory::getInstance().createNpArticulationLink(root, parent, pose);
 	if (!npArticulationLink)
 	{
@@ -264,18 +264,18 @@ PxArticulationLink* NpFactory::createArticulationLink(NpArticulationReducedCoord
 	{
 		PxTransform parentPose = parent->getCMassLocalPose().transformInv(pose);
 		PxTransform childPose = PxTransform(PxIdentity);
-						
+
 		npArticulationJoint = root.createArticulationJoint(*parent, parentPose, *npArticulationLink, childPose);
 		if (!npArticulationJoint)
 		{
 			PX_DELETE(npArticulationLink);
-	
+
 			PxGetFoundation().error(PxErrorCode::eINTERNAL_ERROR, PX_FL, "Articulation link initialization failed due to joint creation failure: returned NULL.");
 			return NULL;
 		}
 
 		npArticulationLink->setInboundJoint(*npArticulationJoint);
-	}	
+	}
 	return npArticulationLink;
 }
 
@@ -299,8 +299,8 @@ void NpFactory::releaseArticulationJointRCToPool(NpArticulationJointReducedCoord
 }
 
 NpArticulationMimicJoint* NpFactory::createNpArticulationMimicJoint
-(const PxArticulationJointReducedCoordinate& jointA, const PxArticulationAxis::Enum axisA, 
- const PxArticulationJointReducedCoordinate& jointB, const PxArticulationAxis::Enum axisB, 
+(const PxArticulationJointReducedCoordinate& jointA, const PxArticulationAxis::Enum axisA,
+ const PxArticulationJointReducedCoordinate& jointB, const PxArticulationAxis::Enum axisB,
  const PxReal gearRatio, const PxReal offset,
  const PxReal naturalFrequency, const PxReal dampingRatio)
 {
@@ -622,7 +622,7 @@ PxMaterial* NpFactory::createMaterial(PxReal staticFriction, PxReal dynamicFrict
 {
 	PX_CHECK_AND_RETURN_NULL(dynamicFriction >= 0.0f, "createMaterial: dynamicFriction must be >= 0.");
 	PX_CHECK_AND_RETURN_NULL(staticFriction >= 0.0f, "createMaterial: staticFriction must be >= 0.");
-	PX_CHECK_AND_RETURN_NULL(restitution >= 0.0f || restitution <= 1.0f, "createMaterial: restitution must be between 0 and 1.");
+	PX_CHECK_AND_RETURN_NULL(restitution >= 0.0f && restitution <= 1.0f, "createMaterial: restitution must be between 0 and 1.");
 
 	PxsMaterialData materialData;
 	materialData.staticFriction = staticFriction;
@@ -631,10 +631,10 @@ PxMaterial* NpFactory::createMaterial(PxReal staticFriction, PxReal dynamicFrict
 
 	NpMaterial* npMaterial;
 	{
-		PxMutex::ScopedLock lock(mMaterialPoolLock);		
+		PxMutex::ScopedLock lock(mMaterialPoolLock);
 		npMaterial = mMaterialPool.construct(materialData);
 	}
-	return npMaterial;	
+	return npMaterial;
 }
 
 void NpFactory::releaseMaterialToPool(NpMaterial& material)
@@ -650,7 +650,7 @@ void NpFactory::releaseMaterialToPool(NpMaterial& material)
 
 ///////////////////////////////////////////////////////////////////////////////
 
-PxDeformableSurfaceMaterial* NpFactory::createDeformableSurfaceMaterial(PxReal youngs, PxReal poissons, PxReal dynamicFriction, PxReal thickness, 
+PxDeformableSurfaceMaterial* NpFactory::createDeformableSurfaceMaterial(PxReal youngs, PxReal poissons, PxReal dynamicFriction, PxReal thickness,
 	PxReal bendingStiffness, PxReal elasticityDamping, PxReal bendingDamping)
 {
 	PX_CHECK_AND_RETURN_NULL(youngs >= 0.0f, "createDeformableSurfaceMaterial: youngs must be >= 0.");
@@ -742,7 +742,7 @@ void NpFactory::releaseDeformableVolumeMaterialToPool(PxDeformableVolumeMaterial
 
 ///////////////////////////////////////////////////////////////////////////////
 
-PxPBDMaterial* NpFactory::createPBDMaterial(PxReal friction, PxReal damping, PxReal adhesion, PxReal viscosity, PxReal vorticityConfinement, 
+PxPBDMaterial* NpFactory::createPBDMaterial(PxReal friction, PxReal damping, PxReal adhesion, PxReal viscosity, PxReal vorticityConfinement,
 	PxReal surfaceTension, PxReal cohesion, PxReal lift, PxReal drag, PxReal cflCoefficient, PxReal gravityScale)
 {
 #if PX_SUPPORT_GPU_PHYSX
@@ -1054,7 +1054,7 @@ void NpFactory::addCollection(const Collection& collection)
 		{
 			NpAggregate* np = static_cast<NpAggregate*>(s);
 			addAggregate(np, false);
-			// PT: TODO: double-check this.... is it correct?			
+			// PT: TODO: double-check this.... is it correct?
 			for(PxU32 j=0;j<np->getCurrentSizeFast();j++)
 			{
 				PxBase* actor = np->getActorFast(j);


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request.

Please write a bug report in the GitHub Issues if you Pull Request fixes a bug and add a link to the Issue.
-->

The discussion is here: https://github.com/NVIDIA-Omniverse/PhysX/discussions/397#discussion-8193281

* It is possible to create a material with `PX_CHECKED` and out of bounds restitution. The check is wrong.
* Fix wrong vectorised min/max extraction leading to missed contacts with PCM mode and with disabled SIMD.
