### PR TITLE
`PxMemCopy` -> `PxMemMove` in `Scene::preallocateContactManagers`

### DIFF
--- a/physx/include/foundation/PxMemory.h
+++ b/physx/include/foundation/PxMemory.h
@@ -81,6 +81,7 @@ namespace physx
 	*/
 	PX_FORCE_INLINE void* PxMemCopy(void* dest, const void* src, PxU32 count)
 	{
+		PX_ASSERT((dest <= src && (char*)dest + count <= src) || (src <= dest && (char*)src + count <= dest));
 		// This is to avoid undefined behavior
 		return (count != 0) ? physx::intrinsics::memCopy(dest, src, count) : NULL;
 	}

--- a/physx/source/simulationcontroller/src/ScPipeline.cpp
+++ b/physx/source/simulationcontroller/src/ScPipeline.cpp
@@ -810,12 +810,12 @@ void Sc::Scene::preallocateContactManagers(PxBaseTask* continuation)
 	{
 		if(filterTask->mNbToKeep || filterTask->mNbToSuppress)
 		{
-			// PT: we pre-compacted surviving pairs in each filtering task so a memcopy is enough here now.
+			// PT: we pre-compacted surviving pairs in each filtering task so a memmove is enough here now.
 			const PxU32 nb = filterTask->mNbToKeep + filterTask->mNbToSuppress;
 			if(pairs + createdOverlapCount != filterTask->mPairs)	// PT: always happens for first task, sometimes for all tasks if nothing was filtered
 			{
-				PxMemCopy(pairs + createdOverlapCount, filterTask->mPairs, sizeof(AABBOverlap) * nb);
-				PxMemCopy(fInfo + createdOverlapCount, filterTask->mFinfo, sizeof(FilterInfo) * nb);
+				PxMemMove(pairs + createdOverlapCount, filterTask->mPairs, sizeof(AABBOverlap) * nb);
+				PxMemMove(fInfo + createdOverlapCount, filterTask->mFinfo, sizeof(FilterInfo) * nb);
 			}
 			createdOverlapCount += nb;
 			batchSize += nb;


### PR DESCRIPTION
Memory regions in question may overlap as they both are spans in `AABBManagerBase::mCreatedOverlaps`

Fixes #425

<!--
Thanks for taking the time to open a Pull Request.

Please write a bug report in the GitHub Issues if you Pull Request fixes a bug and add a link to the Issue.
-->
