### PR TITLE
fix raycast convex hit position issue (#429)

### DIFF
--- a/physx/source/geomutils/src/gjk/GuGJKRaycast.h
+++ b/physx/source/geomutils/src/gjk/GuGJKRaycast.h
@@ -187,7 +187,7 @@ namespace Gu
 		lambda = _lambda;
 		
 		const Vec3V closestP = V3Sel(bNotDegenerated, clos, preClos);
-		Vec3V closA = zeroV, closB = zeroV;
+		Vec3V closA = x, closB = x;
 		getClosestPoint(Q, A, B, closestP, closA, closB, size);
 		closestA = V3Sel(aQuadratic, V3NegScaleSub(nor, a.getMargin(), closA), closA);  
 		


### PR DESCRIPTION
the issue happens when size == 4 here
getClosestPoint does not modify closA
if ray origin is inside convex initially, zeroV is ok however, it is possible to go slightly inside the convex after origin advancing
advanced origin (x) covers both cases

<!--
Thanks for taking the time to open a Pull Request.

Please write a bug report in the GitHub Issues if you Pull Request fixes a bug and add a link to the Issue.
-->
