### PR TITLE
fix: remove unused cudaGL.h include from CudaContextManager

### DIFF
--- a/physx/source/cudamanager/src/CudaContextManager.cpp
+++ b/physx/source/cudamanager/src/CudaContextManager.cpp
@@ -91,7 +91,8 @@ typedef unsigned int GLenum;
 typedef unsigned int GLuint;
 
 //#include <GL/gl.h>
-#include <cudaGL.h>
+// cudaGL.h removed: no CUDA-GL interop functions are called in this file;
+// the include transitively required GL/gl.h which is absent on headless machines.
 #include <assert.h>
 
 #include "foundation/PxErrors.h"


### PR DESCRIPTION
## Problem

`cudaGL.h` is included in `physx/source/cudamanager/src/CudaContextManager.cpp`
but no CUDA-GL interop functions (`cuGraphicsGLRegisterBuffer`,
`cuGLGetDevices`, etc.) are called anywhere in that file.

The include transitively pulls in `<GL/gl.h>`, which is not present on
headless GPU servers (compute-only nodes without a display stack).
This causes a hard build failure on such machines even when the
consuming project does not use GL interop at all.

## Fix

Remove the dead `#include <cudaGL.h>` and replace it with a comment.
The two `typedef` lines above it (`GLenum`, `GLuint`) are already in
place to avoid pulling in `<GL/gl.h>` directly, so no type definitions
are lost.