### PR TITLE
Fix sparse SDF cooking ignoring numThreadsForSdfConstruction

### DIFF
--- a/physx/source/geomutils/src/cooking/GuCookingSDF.cpp
+++ b/physx/source/geomutils/src/cooking/GuCookingSDF.cpp
@@ -233,7 +233,7 @@ static bool createSDFSparse(PxTriangleMeshDesc& desc, PxSDFDesc& sdfDesc, PxArra
 			baseMeshSpecified ? indices32.size() : mesh.m_indices.size(),
 			dx, dy, dz,
 			meshLower, meshLower + PxVec3(static_cast<PxReal>(dx), static_cast<PxReal>(dy), static_cast<PxReal>(dz)) * spacing, narrowBandThickness, sdfDesc.subgridSize,
-			sdfCoarse, sdfSubgridsStartSlots, sparseSdf, denseSdf, subgridsMinSdfValue, subgridsMaxSdfValue, 16, sdfDesc.sdfBuilder);
+			sdfCoarse, sdfSubgridsStartSlots, sparseSdf, denseSdf, subgridsMinSdfValue, subgridsMaxSdfValue, sdfDesc.numThreadsForSdfConstruction, sdfDesc.sdfBuilder);
 
 		PxArray<PxReal> uncompressedSdfDataSubgrids;
 		Gu::convertSparseSDFTo3DTextureLayout(dx, dy, dz, sdfDesc.subgridSize, sdfSubgridsStartSlots.begin(), sparseSdf.begin(), sparseSdf.size(), uncompressedSdfDataSubgrids,


### PR DESCRIPTION
## Summary

One-line bug fix: `SDFUsingWindingNumbersSparse` is called with a **hardcoded 16 threads** instead of using `sdfDesc.numThreadsForSdfConstruction`. This means the user-configured thread count is ignored for sparse SDF cooking.

You can see it in action in this online demo: https://zalo.github.io/PhysicsWorkshop/
Split the box into two colliders, and watch their non-convex shapes fall into each other.

## The bug

In `physx/source/geomutils/src/cooking/GuCookingSDF.cpp` line 236:

```cpp
// Before (hardcoded 16):
Gu::SDFUsingWindingNumbersSparse(..., 16, sdfDesc.sdfBuilder);

// After (respects user setting):
Gu::SDFUsingWindingNumbersSparse(..., sdfDesc.numThreadsForSdfConstruction, sdfDesc.sdfBuilder);
```

The **dense** SDF path already correctly uses `sdfDesc.numThreadsForSdfConstruction` (line 377). This fix makes the sparse path consistent.

## Impact

- **Native**: Users setting `numThreadsForSdfConstruction` to control thread usage during sparse SDF cooking have their setting silently ignored — 16 threads are always spawned.
- **WebAssembly**: Setting `numThreadsForSdfConstruction=1` should produce a fully synchronous cook (the dense path does this correctly), but the sparse path still attempts to create 16 `PxThread` objects, causing an **infinite hang** in environments without pthread support.

## Test plan
- [x] Verified the dense path correctly uses `numThreadsForSdfConstruction` (existing behavior)
- [x] Verified `SDFUsingWindingNumbers` (called by both paths) handles `numThreads=1` by executing synchronously without creating `PxThread` objects
- [x] Tested sparse SDF cooking with `numThreadsForSdfConstruction=1` in Emscripten/WASM — works correctly after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)