### PR TITLE
CUDA 13.x API compatibility

### DIFF
--- a/physx/source/compiler/cmakegpu/CMakeLists.txt
+++ b/physx/source/compiler/cmakegpu/CMakeLists.txt
@@ -88,7 +88,7 @@ IF(PX_GENERATE_GPU_REDUCED_ARCHITECTURES)
 	GENERATE_ARCH_CODE_LIST(SASS "80,86,89,90,100,120" PTX "120")
 ELSE()
 	# Volta is the minimum compute arch required because NGC supports V100
-	GENERATE_ARCH_CODE_LIST(SASS "70,80,86,89,90,100,120" PTX "120")
+	GENERATE_ARCH_CODE_LIST(SASS "80,86,89,90,100,120" PTX "120")
 ENDIF()
 
 # Force response files off because clangd does not parse them

--- a/physx/source/compiler/cmakegpu/CMakeLists.txt
+++ b/physx/source/compiler/cmakegpu/CMakeLists.txt
@@ -85,10 +85,15 @@ SET(SOURCE_DISTRO_FILE_LIST "")
 # since that's the default set in: compiler\internal\CMakeLists.txt (using CMAKE_CUDA_ARCHITECTURES)
 # see policy CMP0104
 IF(PX_GENERATE_GPU_REDUCED_ARCHITECTURES)
-	GENERATE_ARCH_CODE_LIST(SASS "80,86,89,90,100,120" PTX "120")
-ELSE()
-	# Volta is the minimum compute arch required because NGC supports V100
-	GENERATE_ARCH_CODE_LIST(SASS "80,86,89,90,100,120" PTX "120")
+	IF(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 13.0)
+		# CUDA 12.x still supports offline compilation for Volta / sm_70.
+		SET(PHYSX_GPU_SASS_ARCHS "70,80,86,89,90,100,120")
+	ELSE()
+		# CUDA 13.x removed offline compilation support for pre-Turing architectures.
+		SET(PHYSX_GPU_SASS_ARCHS "80,86,89,90,100,120")
+	ENDIF()
+
+GENERATE_ARCH_CODE_LIST(SASS "${PHYSX_GPU_SASS_ARCHS}" PTX "120")
 ENDIF()
 
 # Force response files off because clangd does not parse them

--- a/physx/source/cudamanager/src/CudaContextManager.cpp
+++ b/physx/source/cudamanager/src/CudaContextManager.cpp
@@ -574,7 +574,12 @@ CudaCtxMgr::CudaCtxMgr(const PxCudaContextManagerDesc& desc, PxErrorCallback& er
 				return;
 			}
 			
-			status = cuCtxCreate(&mCtx, (unsigned int)flags, mDevHandle);
+			#if CUDA_VERSION >= 13000
+				status = cuCtxCreate(&mCtx, nullptr, (unsigned int)flags, mDevHandle);
+			#else
+				status = cuCtxCreate(&mCtx, (unsigned int)flags, mDevHandle);
+			#endif
+			
 			if (CUDA_SUCCESS != status)
 			{
 				const size_t bufferSize = 128;

--- a/physx/source/cudamanager/src/CudaKernelWrangler.cpp
+++ b/physx/source/cudamanager/src/CudaKernelWrangler.cpp
@@ -189,6 +189,24 @@ void CUDARTAPI __cudaRegisterFunction(void** fatCubinHandle, const char*,
 
 /* These functions are implemented just to resolve link dependencies */
 
+extern "C" 
+cudaError_t CUDARTAPI __cudaLaunchKernel(
+    const void*,
+    dim3,
+    dim3,
+    void**,
+    size_t,
+    cudaStream_t)
+{
+    return cudaSuccess;
+}
+
+extern "C" 
+const void* CUDARTAPI __cudaGetKernel(const void* func)
+{
+    return func;
+}
+
 extern "C"
 cudaError_t CUDARTAPI cudaLaunch(const char* entry)
 {


### PR DESCRIPTION
## Summary

This PR updates the PhysX GPU source build for CUDA 13.x compatibility.

CUDA Toolkit 13.0 removed offline compilation and library support for pre-Turing architectures, including Volta / `sm_70`, so the default GPU architecture list should no longer emit `sm_70` SASS when building with CUDA 13.x.

CUDA 13.x also changed several generated host-side CUDA entry points and Driver API signatures used by the PhysX GPU build. Since PhysX intentionally avoids linking against CUDART and provides local CUDA runtime stubs in `CudaKernelWrangler.cpp`, this PR adds the missing CUDA 13.x runtime stub symbols instead of linking `cudart_static`.

## Changes

- Keep `sm_70` SASS generation when building with CUDA 12.x.
- Exclude `sm_70` only when building with CUDA 13.x or newer, because CUDA 13.0 removed offline compilation support for pre-Turing architectures.
- Add CUDA 13.x runtime shim symbols used by generated host stubs:
  - `__cudaLaunchKernel`
  - `__cudaGetKernel`
- Update the `cuCtxCreate` call for the CUDA 13.x Driver API signature.

## Motivation

When building `PhysXGpu` with CUDA Toolkit 13.2 on Windows / MSVC, the build currently fails with unresolved external symbols emitted by CUDA-generated host stubs, for example:

```text
unresolved external symbol __cudaLaunchKernel
unresolved external symbol __cudaGetKernel
````

Linking against `cudart_static` is not a suitable fix because `CudaKernelWrangler.cpp` already defines several CUDA runtime shim symbols, which causes duplicate symbol errors such as `__cudaRegisterFatBinary`, `__cudaRegisterFunction`, and `cudaLaunchKernel`.

Keeping these symbols in `CudaKernelWrangler.cpp` preserves the existing PhysX design of resolving CUDA-generated runtime dependencies without linking the full CUDA runtime.

## Validation

Tested locally with:

* Windows
* Visual Studio 2022 / vc17win64
* CUDA Toolkit 13.2
* PhysX GPU source build
* `PhysXGpu` builds past the previous CUDA 13.x link errors
