### PR TITLE
Fix GPU sphere-heightfield crash at boundary edges

### DIFF
--- a/physx/source/gpunarrowphase/src/CUDA/convexHeightfield.cu
+++ b/physx/source/gpunarrowphase/src/CUDA/convexHeightfield.cu
@@ -468,34 +468,55 @@ __device__ PxU32 sphereHeightfieldNarrowphaseCore(
 		{
 		case ConvexTriIntermediateData::eE01:
 		{
-			PxVec3 triLocV0Adj, triLocV1Adj, triLocV2Adj;
-			getTriangle(triLocV0Adj, triLocV1Adj, triLocV2Adj, NULL, triAdjTriIndices.x, heightfieldShape.scale, rows, columns, samples);
-			const PxVec3 triNormalAdj = ((triLocV1Adj - triLocV0Adj).cross(triLocV2Adj - triLocV0Adj)).getNormalized();
+			if (triAdjTriIndices.x != BOUNDARY)
+			{
+				PxVec3 triLocV0Adj, triLocV1Adj, triLocV2Adj;
+				getTriangle(triLocV0Adj, triLocV1Adj, triLocV2Adj, NULL, triAdjTriIndices.x, heightfieldShape.scale, rows, columns, samples);
+				const PxVec3 triNormalAdj = ((triLocV1Adj - triLocV0Adj).cross(triLocV2Adj - triLocV0Adj)).getNormalized();
 
-			generateContact = ((triNormalAdj.dot(triLocV2 - triLocV0Adj)) < 0.f);
+				generateContact = ((triNormalAdj.dot(triLocV2 - triLocV0Adj)) < 0.f);
+			}
+			else
+			{
+				generateContact = true;
+			}
 
 			break;
 		}
 		case ConvexTriIntermediateData::eE12:
 		{
-			PxVec3 triLocV0Adj, triLocV1Adj, triLocV2Adj;
-			getTriangle(triLocV0Adj, triLocV1Adj, triLocV2Adj, NULL, triAdjTriIndices.y, heightfieldShape.scale, rows, columns, samples);
-			const PxVec3 triNormalAdj = ((triLocV1Adj - triLocV0Adj).cross(triLocV2Adj - triLocV0Adj)).getNormalized();
+			if (triAdjTriIndices.y != BOUNDARY)
+			{
+				PxVec3 triLocV0Adj, triLocV1Adj, triLocV2Adj;
+				getTriangle(triLocV0Adj, triLocV1Adj, triLocV2Adj, NULL, triAdjTriIndices.y, heightfieldShape.scale, rows, columns, samples);
+				const PxVec3 triNormalAdj = ((triLocV1Adj - triLocV0Adj).cross(triLocV2Adj - triLocV0Adj)).getNormalized();
 
-			/*printf("%x: triNormalAdj = (%f, %f, %f), triNormal = (%f, %f, %f)\n", triangleIdx, triNormalAdj.x, triNormalAdj.y, triNormalAdj.z, 
-				triNormal.x, triNormal.y, triNormal.z);*/
+				/*printf("%x: triNormalAdj = (%f, %f, %f), triNormal = (%f, %f, %f)\n", triangleIdx, triNormalAdj.x, triNormalAdj.y, triNormalAdj.z,
+					triNormal.x, triNormal.y, triNormal.z);*/
 
-			generateContact = (triNormalAdj.dot(triLocV0 - triLocV0Adj) < 0.f);
+				generateContact = (triNormalAdj.dot(triLocV0 - triLocV0Adj) < 0.f);
+			}
+			else
+			{
+				generateContact = true;
+			}
 			
 			break;
 		}
 		case ConvexTriIntermediateData::eE02:
 		{
-			PxVec3 triLocV0Adj, triLocV1Adj, triLocV2Adj;
-			getTriangle(triLocV0Adj, triLocV1Adj, triLocV2Adj, NULL, triAdjTriIndices.z, heightfieldShape.scale, rows, columns, samples);
-			const PxVec3 triNormalAdj = ((triLocV1Adj - triLocV0Adj).cross(triLocV2Adj - triLocV0Adj)).getNormalized();
+			if (triAdjTriIndices.z != BOUNDARY)
+			{
+				PxVec3 triLocV0Adj, triLocV1Adj, triLocV2Adj;
+				getTriangle(triLocV0Adj, triLocV1Adj, triLocV2Adj, NULL, triAdjTriIndices.z, heightfieldShape.scale, rows, columns, samples);
+				const PxVec3 triNormalAdj = ((triLocV1Adj - triLocV0Adj).cross(triLocV2Adj - triLocV0Adj)).getNormalized();
 
-			generateContact = ((triNormalAdj.dot(triLocV1 - triLocV0Adj)) < 0.f);
+				generateContact = ((triNormalAdj.dot(triLocV1 - triLocV0Adj)) < 0.f);
+			}
+			else
+			{
+				generateContact = true;
+			}
 			break;
 		}
 		


### PR DESCRIPTION
## Summary

Fixes #502.

The GPU sphere-heightfield narrowphase kernel (`sphereHeightfieldNarrowphaseCore`) dereferences the adjacent-triangle index selected by the edge mask (`eE01`, `eE12`, or `eE02`) without checking whether that edge has a neighbor. At the heightfield rim the adjacency index is the sentinel `BOUNDARY (0xFFFFFFFF)`; shifting it in `getTriangleVertexIndices` produces cell index `2147483647`, causing an out-of-bounds `PxHeightFieldSample` read and `CUDA_ERROR_ILLEGAL_ADDRESS`.

When an adjacent index is `BOUNDARY`, this change emits the edge contact directly instead of looking up a nonexistent triangle. A rim edge is a real contact feature, and `PxHeightFieldFlag::eNO_BOUNDARY_EDGES` is documented as ignored for sphere and capsule contact generation.

## Root cause

- `triangle.cuh` defines `BOUNDARY` as `0xFFFFFFFF`.
- `heightfieldUtil.cuh` computes `cell = triangleIndex >> 1`; passing `BOUNDARY` therefore selects cell `2147483647`.
- The three sphere edge cases in `convexHeightfield.cu` called `getTriangle` unconditionally, unlike the guarded adjacent-triangle lookup used by the capsule path.

compute-sanitizer reported the invalid read through:

```text
PxBitAndDataT<unsigned char, 128>::isBitSet
isZerothVertexShared
getTriangleVertexIndices
getTriangle
sphereHeightfieldNarrowphaseCore (convexHeightfield.cu:472)
sphereHeightfieldNarrowphase
```

## Fix

For each sphere edge-contact case:

- keep the existing adjacent-normal test when the adjacency index is valid;
- set `generateContact = true` when the adjacency index is `BOUNDARY`.

This prevents the sentinel dereference while preserving the existing interior-edge behavior.

## Reproduction environment

- `ovphysx` 0.5.10 and current PhysX `main`
- Blackwell GPU (`sm_120`)
- CUDA 12.8 and compute-sanitizer 12.8
- GPU dynamics enabled with sphere bodies against a 64x64-segment heightfield

## Verification

The previously crashing configurations complete successfully with the fix in the GPU reproduction environment:

| Configuration | Before | After |
|---|---:|---:|
| Rolling 64x64 terrain, 1,800 spheres, 240 frames | Crash (100%) | Pass |
| Flat 64x64 heightfield, 5,000 spheres, 240 frames | Crash | Pass |
| Full scene (ring, capsule, and nudges), 1,800 spheres | Crash | Pass |
| Full scene, 2,048 spheres, 300 frames | Crash | Pass |
| Full scene, 3,000 spheres, 300 frames | Crash | Pass |
| Flat heightfield, 8,000 spheres | Crash | Pass |

CPU behavior is unchanged. `git diff --check` also passes. A local CUDA rebuild was not available on the PR preparation host (macOS arm64 without `nvcc`).

## Performance

No measurable impact was observed. Valid adjacent triangles take the same `getTriangle` path as before; the change adds one scalar sentinel comparison per edge case, and the boundary branch is rare.
